### PR TITLE
[ASPW-411] Connection checking

### DIFF
--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -209,9 +209,11 @@ static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         response = enif_make_tuple2(env, erl_error, error_msg);
     } else {
         is_connected = true;
-        // Check if we're actually connected to live servers
-        // aerospike_connect() succeeds even with fail_if_not_connected=false
-        // but this checks if cluster has active, responding nodes
+        // Check if we're actually connected to live servers.
+        // aerospike_connect() returns true with 'fail_if_not_connected' flag set to false
+        // even if there are no live aerospike servers to be connected to, so aerospike_connect()
+        // is useless to tell us if we are connected. On the other hand, the function
+        // aerospike_cluster_is_connected() returns true if we are connected to the cluster.
         ERL_NIF_TERM status;
         if (aerospike_cluster_is_connected(&as)) {
             status = enif_make_atom(env, "connected");
@@ -225,25 +227,24 @@ static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 }
 
 // -spec check_connection() -> atom().
-//
-// Returns connection status to Aerospike cluster.
-//
-// Returns:
-//   disconnected - Disconnected from aerospike cluster.
-//   connected - Successfully connected with active servers available
-//   no_active_servers_found - In a cluster connected state but no active
-//          aerospike servers are found, thus, the cluster is empty.
+// Provides connection status to Aerospike cluster.
+// Returns one of the atom:
+// disconnected - The c-clibrary library is not connected to the cluster NOR
+//      it tries to get connected to the cluster.
+// no_active_servers_found - The c-clibrary library is not connected to the
+//      cluster BUT it tries to get connected to the cluster.
+// connected - Successfully connected to the cluster.
 static ERL_NIF_TERM check_connection(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     if (!is_aerospike_initialised) {
         return enif_make_atom(env, "disconnected");
     }
 
-    if (aerospike_cluster_is_connected(&as)) {
-        return enif_make_atom(env, "connected");
+    if (!aerospike_cluster_is_connected(&as)) {
+        return enif_make_atom(env, "no_active_servers_found");
     }
 
-    return enif_make_atom(env, "no_active_servers_found");
+    return enif_make_atom(env, "connected");
 }
 
 static ERL_NIF_TERM binary_remove(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -237,14 +237,14 @@ static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 static ERL_NIF_TERM check_connection(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     if (!is_aerospike_initialised) {
-        return enif_make_tuple2(env, erl_ok, enif_make_atom(env, "disconnected"));
+        return enif_make_atom(env, "disconnected");
     }
 
     if (aerospike_cluster_is_connected(&as)) {
-        return enif_make_tuple2(env, erl_ok, enif_make_atom(env, "connected"));
+        return enif_make_atom(env, "connected");
     }
 
-    return enif_make_tuple2(env, erl_ok, enif_make_atom(env, "no_active_servers_found"));
+    return enif_make_atom(env, "no_active_servers_found");
 }
 
 static ERL_NIF_TERM binary_remove(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -181,7 +181,7 @@ static ERL_NIF_TERM host_list(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[
 //
 // Returns:
 //   {ok, connected} - Successfully connected with active servers available
-//   {ok, no_active_servers_found} - In cluster connected state but no active
+//   {ok, no_active_servers_found} - In a cluster connected state but no active
 //          aerospike servers are found, thus, the cluster is empty.
 //   {error, ErrorMessage} - Connection failed with error description
 static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -222,6 +222,29 @@ static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
 
     return response;
+}
+
+// -spec check_connection() -> atom().
+//
+// Returns connection status to Aerospike cluster.
+//
+// Returns:
+//   disconnected - Disconnected from aerospike cluster.
+//   connected - Successfully connected with active servers available
+//   no_active_servers_found - In a cluster connected state but no active
+//          aerospike servers are found, thus, the cluster is empty.
+//   {error, ErrorMessage} - Connection failed with error description
+static ERL_NIF_TERM check_connection(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    if (!is_aerospike_initialised) {
+        return enif_make_tuple2(env, erl_ok, enif_make_atom(env, "disconnected"));
+    }
+
+    if (aerospike_cluster_is_connected(&as)) {
+        return enif_make_tuple2(env, erl_ok, enif_make_atom(env, "connected"));
+    }
+
+    return enif_make_tuple2(env, erl_ok, enif_make_atom(env, "no_active_servers_found"));
 }
 
 static ERL_NIF_TERM binary_remove(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -2103,6 +2126,7 @@ static ERL_NIF_TERM bar_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 static ErlNifFunc nif_funcs[] = {
     {"as_init", 0, as_init},
     NIF_FUN("connect", 2, connect),
+    NIF_FUN("check_connection", 2, check_connection),
     NIF_FUN("nif_host_add", 2, host_add),
     NIF_FUN("host_clear", 0, host_clear),
     NIF_FUN("nif_host_list", 0, host_list),

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -233,7 +233,6 @@ static ERL_NIF_TERM connect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 //   connected - Successfully connected with active servers available
 //   no_active_servers_found - In a cluster connected state but no active
 //          aerospike servers are found, thus, the cluster is empty.
-//   {error, ErrorMessage} - Connection failed with error description
 static ERL_NIF_TERM check_connection(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     if (!is_aerospike_initialised) {

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -2126,7 +2126,7 @@ static ERL_NIF_TERM bar_nif(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 static ErlNifFunc nif_funcs[] = {
     {"as_init", 0, as_init},
     NIF_FUN("connect", 2, connect),
-    NIF_FUN("check_connection", 2, check_connection),
+    NIF_FUN("check_connection", 0, check_connection),
     NIF_FUN("nif_host_add", 2, host_add),
     NIF_FUN("host_clear", 0, host_clear),
     NIF_FUN("nif_host_list", 0, host_list),

--- a/src/aspike_nif.erl
+++ b/src/aspike_nif.erl
@@ -74,6 +74,7 @@
     host_clear/0,
     nif_host_list/0,
     connect/2,
+    check_connection/0,
     key_exists/3,
     key_inc/4,
     key_get/3,

--- a/src/aspike_nif.erl
+++ b/src/aspike_nif.erl
@@ -15,6 +15,7 @@
     host_list/0,
     connect/0,
     connect/2,
+    check_connection/0,
     key_exists/0,
     key_exists/1,
     key_exists/3,
@@ -167,6 +168,10 @@ connect() ->
 % @doc Create connection using User and PWd credential
 -spec connect(string(), string()) -> {ok, atom()} | {error, string()}.
 connect(_, _) ->
+    not_loaded(?LINE).
+
+-spec check_connection() -> atom().
+check_connection() ->
     not_loaded(?LINE).
 
 key_exists() ->


### PR DESCRIPTION
Adding ability to check connection with aerospike, the function check_connection()/0 which returns one of the atom:

- disconnected
- connected
- no_active_servers_found
