### PR TITLE
ASPW-743: disabling aspike_port application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
+## Port implementation (disabled)
+
+This repository previously included both a NIF and an Erlang Port implementation
+for communicating with Aerospike. The Port implementation (`aspike_srv`,
+`aspike_port_app`, `aspike_port_sup`) has been disabled because all consumers
+now use the NIF directly via `aspike_nif` module, making the Port process
+unnecessary overhead.
+
+To re-enable the Port implementation:
+
+1. Restore the OTP application callback in `src/aspike_port.app.src`:
+   ```erlang
+   {mod, {aspike_port_app, []}},
+   {included_applications, [pooler]},
+   ```
+
+2. Add the port build back to `c_src/Makefile`:
+   ```makefile
+   %:
+   	$(MAKE) -C port
+   	$(MAKE) -C nif
+   ```
+
 ## Build
 
 You need the aerospike client installed on your machine, which requires

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -2,5 +2,4 @@
 default: all
 
 %:
-	$(MAKE) -C port
 	$(MAKE) -C nif

--- a/src/aspike_port.app.src
+++ b/src/aspike_port.app.src
@@ -1,13 +1,11 @@
 {application, aspike_port,
- [{description, "Erlang port for communication with aerospike"},
+ [{description, "Erlang lib for communication with aerospike"},
   {vsn, "0.1.0"},
   {registered, []},
-  {mod, {aspike_port_app, []}},
   {applications,
    [kernel,
     stdlib
    ]},
-  {included_applications, [pooler]},
   {env,[]},
   {modules, []},
 


### PR DESCRIPTION
## Summary

- Removed the Port process build from `c_src/Makefile` (only NIF is built now)
- Removed the OTP application callback (`aspike_port_app`) and `pooler` dependency from `aspike_port.app.src`
- Updated README with context on why the Port implementation was disabled and how to re-enable it

## Motivation

All consumers now use the NIF directly via `aspike_nif`, making the Port process (`aspike_srv`, `aspike_port_app`, `aspike_port_sup`) unnecessary overhead.

## Test plan

- [x] Verify `rebar3 compile` succeeds without the port build
- [x] Verify NIF-based functionality still works as expected