### PR TITLE
Refactor async node stats: RAII ownership in callback_data

### DIFF
--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -88,15 +88,15 @@ bool check_connected (ErlNifEnv* env, ERL_NIF_TERM* err) {
 }
 
 // Get target node for a key using proper Aerospike partition routing
-string* get_target_node_for_key(const char* namespace_name, const char* set, const char* key_str) {
+string get_target_node_for_key(const char* namespace_name, const char* set, const char* key_str) {
     if (!statistics_enabled_flag || !namespace_name || !key_str || !is_connected_flag || !as.cluster) {
-        return nullptr;
+        return {};
     }
 
     // Use the cluster nodes API which handles reference counting internally
     as_nodes* nodes = as_nodes_reserve(as.cluster);
     if (!nodes) {
-        return nullptr;
+        return {};
     }
 
     // Create a key and compute its digest
@@ -107,7 +107,7 @@ string* get_target_node_for_key(const char* namespace_name, const char* set, con
     if (as_key_set_digest(&err, &key) != AEROSPIKE_OK) {
         as_key_destroy(&key);
         as_nodes_release(nodes);
-        return nullptr;
+        return {};
     }
 
     // Get the digest and compute partition ID
@@ -115,7 +115,7 @@ string* get_target_node_for_key(const char* namespace_name, const char* set, con
     if (!digest) {
         as_key_destroy(&key);
         as_nodes_release(nodes);
-        return nullptr;
+        return {};
     }
 
     // Get partition table for this namespace
@@ -133,7 +133,7 @@ string* get_target_node_for_key(const char* namespace_name, const char* set, con
     if (!table) {
         as_key_destroy(&key);
         as_nodes_release(nodes);
-        return nullptr;
+        return {};
     }
 
     // Calculate partition ID
@@ -148,10 +148,10 @@ string* get_target_node_for_key(const char* namespace_name, const char* set, con
                                                  nullptr, AS_POLICY_REPLICA_MASTER,
                                                  1, &replica_index);
 
-    string* node_name = nullptr;
+    string node_name;
     if (target_node && strlen(target_node->name) > 0) {
-        // make a copy of node name because the pointer to it may be deleted
-        node_name = new string((char *)target_node->name);
+        // copy node name while nodes reference is held, as the node may be destroyed after release
+        node_name = target_node->name;
     }
 
     as_key_destroy(&key);
@@ -161,11 +161,11 @@ string* get_target_node_for_key(const char* namespace_name, const char* set, con
 }
 
 // Get or create stats for a node (thread-safe with reader-writer lock)
-shared_ptr<NodeConnectionStats> get_or_create_node_stats(string* node_name) {
+shared_ptr<NodeConnectionStats> get_or_create_node_stats(const string& node_name) {
     // Fast path: shared lock for reading (multiple threads can access simultaneously)
     {
         shared_lock<shared_mutex> read_lock(node_stats_rw_mutex);
-        auto it = node_stats_map.find(*node_name);
+        auto it = node_stats_map.find(node_name);
         if (it != node_stats_map.end()) {
             return it->second;
         }
@@ -175,18 +175,14 @@ shared_ptr<NodeConnectionStats> get_or_create_node_stats(string* node_name) {
     lock_guard<shared_mutex> write_lock(node_stats_rw_mutex);
 
     // Double-check: another thread might have created it while we waited for the lock
-    auto it2 = node_stats_map.find(*node_name);
+    auto it2 = node_stats_map.find(node_name);
     if (it2 != node_stats_map.end()) {
         return it2->second;
     }
 
     // Create new stats entry
     auto stats = make_shared<NodeConnectionStats>();
-    // create a string copy because this might be gone immediately
-    // it can be seen as a memory leak if the node_name are not unique,
-    // but fortunately (seem like) the node names are static and not changed.
-    string * copy = new string(*node_name);
-    node_stats_map[*copy] = stats;
+    node_stats_map[node_name] = stats;
     return stats;
 }
 

--- a/c_src/nif/aspike_nif.h
+++ b/c_src/nif/aspike_nif.h
@@ -48,8 +48,8 @@ extern atomic<uint32_t> async_current_counter;
 extern atomic<uint32_t> async_peak_counter;
 extern atomic<int64_t> async_peak_ttl_counter;
 
-extern string* get_target_node_for_key (const char* namespace_name, const char* set, const char* key_str);
-extern shared_ptr<NodeConnectionStats> get_or_create_node_stats (string* node_name);
+extern string get_target_node_for_key (const char* namespace_name, const char* set, const char* key_str);
+extern shared_ptr<NodeConnectionStats> get_or_create_node_stats (const string& node_name);
 
 extern aerospike* get_aerospike ();
 extern bool statistics_enabled ();

--- a/c_src/nif/async_methods.cpp
+++ b/c_src/nif/async_methods.cpp
@@ -38,38 +38,6 @@
 
 using namespace std;
 
-void increment_async_connection_counter_with_node(string * node_name) {
-    if (!node_name) return;
-    auto node_stats = get_or_create_node_stats(node_name);
-
-    // Increment both global and per-node counters
-    async_current_counter.fetch_add(1);
-    node_stats->async_current.fetch_add(1);
-
-    auto global_value = async_current_counter.load();
-    auto node_value = node_stats->async_current.load();
-    auto now = unix_ts();
-
-    // Update global peaks
-    if (async_peak_counter.load() < global_value || async_peak_ttl_counter.load() < now) {
-        async_peak_counter.store(global_value);
-        async_peak_ttl_counter.store(now + 15);
-    }
-
-    // Update node-specific peaks
-    if (node_stats->async_peak.load() < node_value || node_stats->async_peak_ttl.load() < now) {
-        node_stats->async_peak.store(node_value);
-        node_stats->async_peak_ttl.store(now + 15);
-    }
-}
-
-void decrement_async_connection_counter_with_node(string* node_name) {
-    if (!node_name) return;
-    async_current_counter.fetch_sub(1);
-    auto node_stats = get_or_create_node_stats(node_name);
-    node_stats->async_current.fetch_sub(1);
-}
-
 // Async callback structure for async operations
 struct callback_data {
     // 'pi_env' means Process Independent Environment, and in the async functions below
@@ -81,7 +49,7 @@ struct callback_data {
     vector<as_arraylist>* arraylist_vector = nullptr;
     vector<as_operations>* operations_vector = nullptr;
     as_batch_records* batch_records = nullptr;
-    string* node_name = nullptr;
+    string node_name;
     string* bin_name = nullptr;
 
     callback_data(ErlNifEnv* caller_pd_env, const ERL_NIF_TERM ref_to_save) {
@@ -91,7 +59,41 @@ struct callback_data {
         ref = enif_make_copy(erl_pi_env, ref_to_save);
     }
 
+    callback_data(ErlNifEnv* caller_pd_env, const ERL_NIF_TERM ref_to_save,
+        const string& name_space, const string& set_name, const string& record_name)
+        : callback_data(caller_pd_env, ref_to_save) {
+        if (!statistics_enabled()) return;
+        node_name = get_target_node_for_key(name_space.c_str(), set_name.c_str(), record_name.c_str());
+        if (node_name.empty()) return;
+        auto node_stats = get_or_create_node_stats(node_name);
+
+        // Increment both global and per-node counters
+        async_current_counter.fetch_add(1);
+        node_stats->async_current.fetch_add(1);
+
+        auto global_value = async_current_counter.load();
+        auto node_value = node_stats->async_current.load();
+        auto now = unix_ts();
+
+        // Update global peaks
+        if (async_peak_counter.load() < global_value || async_peak_ttl_counter.load() < now) {
+            async_peak_counter.store(global_value);
+            async_peak_ttl_counter.store(now + 15);
+        }
+
+        // Update node-specific peaks
+        if (node_stats->async_peak.load() < node_value || node_stats->async_peak_ttl.load() < now) {
+            node_stats->async_peak.store(node_value);
+            node_stats->async_peak_ttl.store(now + 15);
+        }
+    }
+
     ~callback_data() {
+        if (!node_name.empty() && statistics_enabled()) {
+            async_current_counter.fetch_sub(1);
+            auto node_stats = get_or_create_node_stats(node_name);
+            node_stats->async_current.fetch_sub(1);
+        }
         if (batch_records) {
             as_batch_records_destroy(batch_records);
             delete batch_records;
@@ -115,10 +117,6 @@ struct callback_data {
             enif_free_env(erl_pi_env);
             erl_pi_env = nullptr;
         }
-        if (node_name) {
-            delete node_name;
-            node_name = nullptr;
-        }
         if (bin_name) {
             delete bin_name;
             bin_name = nullptr;
@@ -130,10 +128,6 @@ static void cdt_put_async_callback(as_error* err, as_record* record, void* udata
     callback_data* cb_data = (callback_data*)udata;
 
     ERL_NIF_TERM result_msg;
-
-    if (cb_data->node_name && statistics_enabled()) {
-        decrement_async_connection_counter_with_node(cb_data->node_name);
-    }
 
     if (err) {
         ERL_NIF_TERM error_msg;
@@ -264,21 +258,12 @@ ERL_NIF_TERM aspike_nif_cdt_put_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
         operations.ttl = -2;
     }
 
-    string * node_name = nullptr;
-    if (statistics_enabled()) {
-        node_name = get_target_node_for_key(name_space.c_str(), set_name.c_str(), record_name.c_str());
-        if (node_name) {
-            increment_async_connection_counter_with_node(node_name);
-        }
-    }
-
     as_key record_key;
     as_key_init_str(&record_key, name_space.c_str(), set_name.c_str(), record_name.c_str());
 
     vector<as_cdt_ctx*> cdt_contexts;
 
-    auto cb_data = new callback_data(env, argv[0]);
-    cb_data->node_name = node_name;
+    auto cb_data = new callback_data(env, argv[0], name_space, set_name, record_name);
 
     as_map_policy put_mode;
     as_map_policy_set(&put_mode, AS_MAP_KEY_ORDERED, AS_MAP_UPDATE);
@@ -417,9 +402,6 @@ ERL_NIF_TERM aspike_nif_cdt_put_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
     as_key_destroy(&record_key);
 
     if (status != AEROSPIKE_OK) {
-        if (statistics_enabled()) {
-            decrement_async_connection_counter_with_node(node_name);
-        }
         delete cb_data;
 
         ERL_NIF_TERM error_msg;
@@ -444,10 +426,6 @@ static void cdt_get_async_callback(as_error* err, as_record* record, void* udata
     callback_data* cb_data = (callback_data*)udata;
 
     ERL_NIF_TERM result_msg;
-
-    if (cb_data->node_name && statistics_enabled()) {
-        decrement_async_connection_counter_with_node(cb_data->node_name);
-    }
 
     if (err) {
         ERL_NIF_TERM error_msg;
@@ -520,19 +498,10 @@ ERL_NIF_TERM aspike_nif_cdt_get_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
     ERL_NIF_TERM return_data;
     if (check_connected(env, &return_data)) return return_data;
 
-    string * node_name = nullptr;
-    if (statistics_enabled()) {
-        node_name = get_target_node_for_key(name_space.c_str(), set_name.c_str(), record_name.c_str());
-        if (node_name) {
-            increment_async_connection_counter_with_node(node_name);
-        }
-    }
-
     as_key record_key;
     as_key_init_str(&record_key, name_space.c_str(), set_name.c_str(), record_name.c_str());
 
-    auto cb_data = new callback_data(env, argv[0]);
-    cb_data->node_name = node_name;
+    auto cb_data = new callback_data(env, argv[0], name_space, set_name, record_name);
 
     as_error err;
     as_status status = aerospike_key_get_async(as, &err, &policy, &record_key, cdt_get_async_callback, cb_data, NULL, NULL);
@@ -540,9 +509,6 @@ ERL_NIF_TERM aspike_nif_cdt_get_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
     as_key_destroy(&record_key);
 
     if (status != AEROSPIKE_OK) {
-        if (statistics_enabled()) {
-            decrement_async_connection_counter_with_node(node_name);
-        }
         delete cb_data;
 
         ERL_NIF_TERM error_msg;
@@ -567,10 +533,6 @@ static void cdt_delete_by_keys_async_callback(as_error* err, as_record* record, 
     callback_data* cb_data = (callback_data*)udata;
 
     ERL_NIF_TERM result_msg;
-
-    if (cb_data->node_name && statistics_enabled()) {
-        decrement_async_connection_counter_with_node(cb_data->node_name);
-    }
 
     if (err) {
         ERL_NIF_TERM error_msg;
@@ -634,14 +596,6 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_async(ErlNifEnv* env, int argc, const
     string record_name((const char*)erl_record_name.data, erl_record_name.size);
     string bin_name((const char*)erl_bin_name.data, erl_bin_name.size);
 
-    string * node_name = nullptr;
-    if (statistics_enabled()) {
-        node_name = get_target_node_for_key(name_space.c_str(), set_name.c_str(), record_name.c_str());
-        if (node_name) {
-            increment_async_connection_counter_with_node(node_name);
-        }
-    }
-
     as_arraylist remove_list;
     as_arraylist_init(&remove_list, length, length);
 
@@ -665,7 +619,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_async(ErlNifEnv* env, int argc, const
         }
         if (enif_inspect_binary(env, head, &subkey_term)) {
             // we have to allocate memory for subkey_str because function subkey_term.data
-            // may be not a null-terminated string, and passing subkey_term.data to 
+            // may be not a null-terminated string, and passing subkey_term.data to
             // as_arraylist_append_str() might be a bad idea.
             subkey_str.assign((const char*)subkey_term.data, subkey_term.size);
             as_arraylist_append_str(&remove_list, (char*)subkey_str.c_str());
@@ -679,8 +633,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_async(ErlNifEnv* env, int argc, const
         as_operations_add_map_remove_by_key_list(&operations, bin_name.c_str(), (as_list*)&remove_list, AS_MAP_RETURN_NONE);
     }
 
-    auto cb_data = new callback_data(env, argv[0]);
-    cb_data->node_name = node_name;
+    auto cb_data = new callback_data(env, argv[0], name_space, set_name, record_name);
 
     as_error err;
     as_status status = aerospike_key_operate_async(as, &err, NULL, &record_key, &operations, cdt_delete_by_keys_async_callback, cb_data, NULL, NULL);
@@ -690,9 +643,6 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_async(ErlNifEnv* env, int argc, const
     as_key_destroy(&record_key);
 
     if (status != AEROSPIKE_OK) {
-        if (statistics_enabled()) {
-            decrement_async_connection_counter_with_node(node_name);
-        }
         delete cb_data;
 
         ERL_NIF_TERM error_msg;
@@ -907,10 +857,6 @@ void segment_tag_get_async_callback(as_error* err, as_record* records, void* uda
 
     ERL_NIF_TERM result_msg;
 
-    if (cb_data->node_name && statistics_enabled()) {
-        decrement_async_connection_counter_with_node(cb_data->node_name);
-    }
-
     if (err) {
         ERL_NIF_TERM error_msg;
 
@@ -1023,21 +969,13 @@ ERL_NIF_TERM aspike_nif_segment_tag_get_async(ErlNifEnv* env, int argc, const ER
     string record_name((const char*)erl_record_name.data, erl_record_name.size);
     auto bin_name = new string((const char*)erl_bin_name.data, erl_bin_name.size);
 
-    string * node_name = nullptr;
-    if (statistics_enabled()) {
-        node_name = get_target_node_for_key(name_space.c_str(), set_name.c_str(), record_name.c_str());
-        if (node_name) {
-            increment_async_connection_counter_with_node(node_name);
-        }
-    }
-
     as_key record_key;
     as_key_init_str(&record_key, name_space.c_str(), set_name.c_str(), record_name.c_str());
 
     const char* bins_to_read[] = {(*bin_name).c_str(), NULL};
 
-    auto cb_data = new callback_data(env, argv[0]);
-    cb_data->node_name = node_name;
+    auto cb_data = new callback_data(env, argv[0], name_space, set_name, record_name);
+
     // we save bin_name because we'll need it in the segment_tag_get_async_callback()
     cb_data->bin_name = bin_name;
 
@@ -1047,9 +985,6 @@ ERL_NIF_TERM aspike_nif_segment_tag_get_async(ErlNifEnv* env, int argc, const ER
     as_key_destroy(&record_key);
 
     if (status != AEROSPIKE_OK) {
-        if (statistics_enabled()) {
-            decrement_async_connection_counter_with_node(node_name);
-        }
         delete cb_data;
 
         ERL_NIF_TERM error_msg;

--- a/c_src/nif/async_methods.cpp
+++ b/c_src/nif/async_methods.cpp
@@ -46,11 +46,12 @@ struct callback_data {
     ErlNifEnv* erl_pi_env = nullptr;
     ErlNifPid caller_pid;
     ERL_NIF_TERM ref;
-    vector<as_arraylist>* arraylist_vector = nullptr;
-    vector<as_operations>* operations_vector = nullptr;
-    as_batch_records* batch_records = nullptr;
+    vector<as_arraylist> arraylist_vector;
+    vector<as_operations> operations_vector;
+    as_batch_records batch_records = {};
+    bool batch_records_initialized = false;
     string node_name;
-    string* bin_name = nullptr;
+    string bin_name;
 
     callback_data(ErlNifEnv* caller_pd_env, const ERL_NIF_TERM ref_to_save) {
         enif_self(caller_pd_env, &caller_pid);
@@ -94,32 +95,18 @@ struct callback_data {
             auto node_stats = get_or_create_node_stats(node_name);
             node_stats->async_current.fetch_sub(1);
         }
-        if (batch_records) {
-            as_batch_records_destroy(batch_records);
-            delete batch_records;
-            batch_records = nullptr;
+        if (batch_records_initialized) {
+            as_batch_records_destroy(&batch_records);
         }
-        if (arraylist_vector) {
-            for (auto& arraylist : *arraylist_vector) {
-                as_arraylist_destroy(&arraylist);
-            }
-            delete arraylist_vector;
-            arraylist_vector = nullptr;
+        for (auto& arraylist : arraylist_vector) {
+            as_arraylist_destroy(&arraylist);
         }
-        if (operations_vector) {
-            for (auto& operations : *operations_vector) {
-                as_operations_destroy(&operations);
-            }
-            delete operations_vector;
-            operations_vector = nullptr;
+        for (auto& operations : operations_vector) {
+            as_operations_destroy(&operations);
         }
         if (erl_pi_env) {
             enif_free_env(erl_pi_env);
             erl_pi_env = nullptr;
-        }
-        if (bin_name) {
-            delete bin_name;
-            bin_name = nullptr;
         }
     }
 };
@@ -772,12 +759,13 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_batch_async(ErlNifEnv* env, int argc,
 
     vector<string> pk_names(tuples_amount);
     vector<as_batch_write_record*> batch_writes(tuples_amount);
-    auto delete_ops = new vector<as_operations>(tuples_amount);
-    auto map_keys = new vector<as_arraylist>(tuples_amount);
     string map_key_name;
 
-    auto recs = new as_batch_records();
-    as_batch_records_init(recs, tuples_amount);
+    auto cb_data = new callback_data(env, argv[0]);
+    cb_data->operations_vector.resize(tuples_amount);
+    cb_data->arraylist_vector.resize(tuples_amount);
+    as_batch_records_init(&cb_data->batch_records, tuples_amount);
+    cb_data->batch_records_initialized = true;
 
     erl_current_list = erl_tuples;
     for (uint tuple_index = 0; tuple_index < tuples_amount; tuple_index++) {
@@ -790,40 +778,35 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_batch_async(ErlNifEnv* env, int argc,
         enif_is_list(env, erl_tuple[1]);
         enif_get_list_length(env, erl_tuple[1], &map_keys_amount);
 
-        batch_writes[tuple_index] = as_batch_write_reserve(recs);
+        batch_writes[tuple_index] = as_batch_write_reserve(&cb_data->batch_records);
         as_key_init_str(&(batch_writes[tuple_index]->key), name_space.c_str(), set_name.c_str(), pk_names[tuple_index].c_str());
 
-        as_arraylist_init(&((*map_keys)[tuple_index]), map_keys_amount, map_keys_amount);
+        as_arraylist_init(&(cb_data->arraylist_vector[tuple_index]), map_keys_amount, map_keys_amount);
 
         erl_map_keys = erl_tuple[1];
         for (uint k = 0; k < map_keys_amount; k++) {
-            
+
             enif_get_list_cell(env, erl_map_keys, &erl_map_keys_head, &erl_map_keys_tail);
             enif_inspect_binary(env, erl_map_keys_head, &erl_map_key_name);
 
             map_key_name.assign((const char*)erl_map_key_name.data, erl_map_key_name.size);
             // we can use stack variable here because as_arraylist_append_str will strdup(map_key_name)
             // and free the string automatically once the map_keys[tuple_index] is destroyed
-            as_arraylist_append_str(&((*map_keys)[tuple_index]), (char*)map_key_name.c_str());
+            as_arraylist_append_str(&(cb_data->arraylist_vector[tuple_index]), (char*)map_key_name.c_str());
 
             erl_map_keys = erl_map_keys_tail;
         }
-        
-        as_operations_init(&((*delete_ops)[tuple_index]), 1);
-        as_operations_add_map_remove_by_key_list(&((*delete_ops)[tuple_index]), bin_name.c_str(), (as_list*)&((*map_keys)[tuple_index]), AS_MAP_RETURN_NONE);
-        (*delete_ops)[tuple_index].ttl = AS_RECORD_NO_CHANGE_TTL;
-        batch_writes[tuple_index]->ops = &((*delete_ops)[tuple_index]);
+
+        as_operations_init(&(cb_data->operations_vector[tuple_index]), 1);
+        as_operations_add_map_remove_by_key_list(&(cb_data->operations_vector[tuple_index]), bin_name.c_str(), (as_list*)&(cb_data->arraylist_vector[tuple_index]), AS_MAP_RETURN_NONE);
+        cb_data->operations_vector[tuple_index].ttl = AS_RECORD_NO_CHANGE_TTL;
+        batch_writes[tuple_index]->ops = &(cb_data->operations_vector[tuple_index]);
 
         erl_current_list = erl_tail;
     }
 
-    auto cb_data = new callback_data(env, argv[0]);
-    cb_data->batch_records = recs;
-    cb_data->arraylist_vector = map_keys;
-    cb_data->operations_vector = delete_ops;
-
     as_error err;
-    as_status status = aerospike_batch_write_async(as, &err, nullptr, recs, cdt_delete_by_keys_batch_async_callback, cb_data, nullptr);
+    as_status status = aerospike_batch_write_async(as, &err, nullptr, &cb_data->batch_records, cdt_delete_by_keys_batch_async_callback, cb_data, nullptr);
 
     if (status != AEROSPIKE_OK) {
         delete cb_data;
@@ -880,7 +863,7 @@ void segment_tag_get_async_callback(as_error* err, as_record* records, void* uda
 
         try {
             if (records == NULL) throw "NULL p_rec";
-            as_bin_value* bin = as_record_get(records, cb_data->bin_name->c_str());
+            as_bin_value* bin = as_record_get(records, cb_data->bin_name.c_str());
             if (bin == NULL) {
                 throw "NULL val - internal error";
             }
@@ -967,17 +950,14 @@ ERL_NIF_TERM aspike_nif_segment_tag_get_async(ErlNifEnv* env, int argc, const ER
     string name_space((const char*)erl_ns.data, erl_ns.size);
     string set_name((const char*)erl_set_name.data, erl_set_name.size);
     string record_name((const char*)erl_record_name.data, erl_record_name.size);
-    auto bin_name = new string((const char*)erl_bin_name.data, erl_bin_name.size);
-
     as_key record_key;
     as_key_init_str(&record_key, name_space.c_str(), set_name.c_str(), record_name.c_str());
 
-    const char* bins_to_read[] = {(*bin_name).c_str(), NULL};
-
     auto cb_data = new callback_data(env, argv[0], name_space, set_name, record_name);
-
     // we save bin_name because we'll need it in the segment_tag_get_async_callback()
-    cb_data->bin_name = bin_name;
+    cb_data->bin_name.assign((const char*)erl_bin_name.data, erl_bin_name.size);
+
+    const char* bins_to_read[] = {cb_data->bin_name.c_str(), NULL};
 
     as_error err;
     as_status status = aerospike_key_select_async(as, &err, nullptr, &record_key, bins_to_read, segment_tag_get_async_callback, cb_data, nullptr, nullptr);


### PR DESCRIPTION
Move node name resolution and connection counter management into callback_data constructor/destructor, eliminating scattered increment/decrement calls and raw pointer ownership ambiguity.

- get_target_node_for_key() returns string by value instead of string*
- get_or_create_node_stats() takes const string& instead of string*
- callback_data owns node_name as string value, not heap-allocated pointer
- Second constructor resolves node and increments counter atomically
- Destructor decrements counter automatically (RAII)
- Removes leaked string allocation in node_stats_map