### PR TITLE
Improves for error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ensure_aerospike_test:
 		echo "Starting Aerospike Docker container..."; \
 		docker run -d --rm --name aerospike_test --ulimit nofile=65536:65536 \
 			-p 3000:3000 -p 3001:3001 -p 3002:3002 -p 3003:3003 aerospike:ce-7.1.0.0; \
-		sleep 1; \
+		sleep 3; \
 	fi
 
 test: ensure_aerospike_test

--- a/Makefile
+++ b/Makefile
@@ -35,15 +35,14 @@ ensure_aerospike_test:
 	fi
 
 test: ensure_aerospike_test
-	rebar3 eunit --module=aspike_nif_not_connected_test --verbose
-	rebar3 eunit --module=aspike_nif_eunit_test --verbose
+	rebar3 eunit --verbose
 
 stress_test: ensure_aerospike_test
 	rebar3 as test compile
-	erl -pa _build/test/lib/aspike_port/ebin -pa _build/test/lib/pooler/ebin \
+	erl -pa _build/test/lib/aspike_port/ebin -pa _build/test/lib/aspike_port/test \
 		-noshell -s aspike_nif_test stress_test
 
 memory_leak_test: ensure_aerospike_test
 	rebar3 as test compile
-	erl -pa _build/test/lib/aspike_port/ebin -pa _build/test/lib/pooler/ebin \
+	erl -pa _build/test/lib/aspike_port/ebin -pa _build/test/lib/aspike_port/test \
 		-noshell -s aspike_nif_test memory_leak_test

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ ensure_aerospike_test:
 	fi
 
 test: ensure_aerospike_test
+	rebar3 eunit --module=aspike_nif_not_connected_test --verbose
 	rebar3 eunit --module=aspike_nif_eunit_test --verbose
 
 stress_test: ensure_aerospike_test

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -363,6 +363,30 @@ static ERL_NIF_TERM aspike_nif_connect(ErlNifEnv* env, int argc, const ERL_NIF_T
     return response;
 }
 
+static ERL_NIF_TERM aspike_nif_disconnect(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    if (!is_connected_flag) {
+        return enif_make_tuple2(env, atom_ok, enif_make_string(env, "disconnected", ERL_NIF_UTF8));
+    }
+
+    as_error err;
+    as_status rc = aerospike_close(&as, &err);
+    if (rc != AEROSPIKE_OK) {
+        ERL_NIF_TERM error_msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
+        return enif_make_tuple2(env, atom_error, error_msg);
+    }
+
+    is_connected_flag = false;
+    aerospike_destroy(&as);
+
+    // Re-initialize so host_add/connect can be called again
+    as_config config;
+    as_config_init(&config);
+    aerospike_init(&as, &config);
+
+    return enif_make_tuple2(env, atom_ok, enif_make_string(env, "disconnected", ERL_NIF_UTF8));
+}
+
 // -spec is_connected_check() -> false | true.
 // Provides connection status to Aerospike cluster.
 // Returns one of the atom:
@@ -687,6 +711,7 @@ static ErlNifFunc nif_funcs[] = {
     {"host_clear", 0, aspike_nif_host_clear},
     {"nif_host_list", 0, aspike_nif_host_list},
     NIF_DIRTY_FUN("connect", 2, aspike_nif_connect),
+    NIF_DIRTY_FUN("disconnect", 0, aspike_nif_disconnect),
     {"is_connected", 0, aspike_nif_is_connected_check},
     NIF_DIRTY_FUN("nif_node_random", 0, aspike_nif_node_random),
     NIF_DIRTY_FUN("nif_node_names", 0, aspike_nif_node_names),

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -48,6 +48,7 @@ using namespace std;
 
 aerospike as;
 bool is_connected_flag = false;
+static bool is_initialized = false;
 bool statistics_enabled_flag = false;
 static as_monitor app_complete_monitor;
 static uint32_t event_loops_amount = 1;
@@ -191,12 +192,23 @@ shared_ptr<NodeConnectionStats> get_or_create_node_stats(const string& node_name
 
 // ----------------------------------------------------------------------------
 
-static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
-{
+static void init_aerospike_client() {
+    if (is_initialized) return;
     as_config config;
     as_config_init(&config);
-
     aerospike_init(&as, &config);
+    is_initialized = true;
+}
+
+static ERL_NIF_TERM aspike_nif_init_client(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+    init_aerospike_client();
+    return enif_make_tuple2(env, atom_ok, enif_make_string(env, "initialized", ERL_NIF_UTF8));
+}
+
+static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
+{
+    init_aerospike_client();
 
     // the following atoms are definitely present in the VM but to keep code short and
     // simple we call enif_make_atom() instead of enif_make_existing_atom(). Plus, who
@@ -378,11 +390,7 @@ static ERL_NIF_TERM aspike_nif_disconnect(ErlNifEnv* env, int argc, const ERL_NI
 
     is_connected_flag = false;
     aerospike_destroy(&as);
-
-    // Re-initialize so host_add/connect can be called again
-    as_config config;
-    as_config_init(&config);
-    aerospike_init(&as, &config);
+    is_initialized = false;
 
     return enif_make_tuple2(env, atom_ok, enif_make_string(env, "disconnected", ERL_NIF_UTF8));
 }
@@ -707,6 +715,7 @@ static ErlNifFunc nif_funcs[] = {
     {"set_connections_per_node", 4, aspike_nif_set_connections_per_node},
     {"set_event_loops_amount", 1, aspike_nif_set_event_loops_amount},
     {"enable_statistic_collection", 1, aspike_nif_enable_statistic_collection},
+    {"init_client", 0, aspike_nif_init_client},
     {"nif_host_add", 2, aspike_nif_host_add},
     {"host_clear", 0, aspike_nif_host_clear},
     {"nif_host_list", 0, aspike_nif_host_list},

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -58,7 +58,6 @@ ERL_NIF_TERM atom_done;
 ERL_NIF_TERM atom_true;
 ERL_NIF_TERM atom_false;
 ERL_NIF_TERM atom_connected;
-ERL_NIF_TERM atom_not_connected;
 ERL_NIF_TERM atom_in_progress;
 ERL_NIF_TERM atom_undefined;
 
@@ -81,10 +80,14 @@ bool statistics_enabled () {
 
 bool check_connected (ErlNifEnv* env, ERL_NIF_TERM* err) {
     if (!is_connected_flag) {
-        *err = enif_make_tuple2(env, atom_error, atom_not_connected);
-        return true;
+        auto nifErrorCode = enif_make_int(env, ASPIKE_NIF_NOT_CONNECTED);
+        auto aspikeErrorCode = enif_make_int(env, AEROSPIKE_ERR_CLIENT);
+        auto msg = enif_make_string(env, "not_connected", ERL_NIF_UTF8);
+        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, nifErrorCode, aspikeErrorCode, msg);
+        *err = enif_make_tuple2(env, atom_error, error_tuple);
+        return false;
     }
-    return false;
+    return true;
 }
 
 // Get target node for a key using proper Aerospike partition routing
@@ -204,7 +207,6 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
     atom_true = enif_make_atom(env, "true");
     atom_false = enif_make_atom(env, "false");
     atom_connected = enif_make_atom(env, "connected");
-    atom_not_connected = enif_make_atom(env, "not_connected");
     atom_in_progress = enif_make_atom(env, "in_progress");
     atom_undefined = enif_make_atom(env, "undefined");
 
@@ -384,7 +386,7 @@ static ERL_NIF_TERM aspike_nif_is_connected_check(ErlNifEnv* env, int argc, cons
 static ERL_NIF_TERM aspike_nif_node_random(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     as_node* node = as_node_get_random(as.cluster);
@@ -403,7 +405,7 @@ static ERL_NIF_TERM aspike_nif_node_random(ErlNifEnv* env, int argc, const ERL_N
 static ERL_NIF_TERM aspike_nif_node_names(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc;
 	as_nodes* nodes = as_nodes_reserve(as.cluster);
@@ -434,7 +436,7 @@ static ERL_NIF_TERM aspike_nif_node_get(ErlNifEnv* env, int argc, const ERL_NIF_
 	    return enif_make_badarg(env);
     }
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
     ERL_NIF_TERM rc, msg;
 
     as_node* node = as_node_get_by_name(as.cluster, node_name);
@@ -461,7 +463,7 @@ static ERL_NIF_TERM aspike_nif_node_info(ErlNifEnv* env, int argc, const ERL_NIF
 	    return enif_make_badarg(env);
     }
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
     ERL_NIF_TERM rc, msg;
 
 	as_cluster* cluster = as.cluster;
@@ -501,7 +503,7 @@ static ERL_NIF_TERM aspike_nif_help(ErlNifEnv* env, int argc, const ERL_NIF_TERM
 	    return enif_make_badarg(env);
     }
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
     ERL_NIF_TERM rc, msg;
     char * info = NULL;
     as_error err;
@@ -536,7 +538,7 @@ static ERL_NIF_TERM aspike_nif_host_info(ErlNifEnv* env, int argc, const ERL_NIF
 	    return enif_make_badarg(env);
     }
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
     ERL_NIF_TERM rc, msg;
     as_error err;
     as_address_iterator iter;

--- a/c_src/nif/aspike_nif.cpp
+++ b/c_src/nif/aspike_nif.cpp
@@ -78,7 +78,7 @@ bool statistics_enabled () {
     return statistics_enabled_flag;
 }
 
-bool check_connected (ErlNifEnv* env, ERL_NIF_TERM* err) {
+bool is_connected (ErlNifEnv* env, ERL_NIF_TERM* err) {
     if (!is_connected_flag) {
         auto nifErrorCode = enif_make_int(env, ASPIKE_NIF_NOT_CONNECTED);
         auto aspikeErrorCode = enif_make_int(env, AEROSPIKE_ERR_CLIENT);
@@ -410,7 +410,7 @@ static ERL_NIF_TERM aspike_nif_is_connected_check(ErlNifEnv* env, int argc, cons
 static ERL_NIF_TERM aspike_nif_node_random(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     as_node* node = as_node_get_random(as.cluster);
@@ -429,7 +429,7 @@ static ERL_NIF_TERM aspike_nif_node_random(ErlNifEnv* env, int argc, const ERL_N
 static ERL_NIF_TERM aspike_nif_node_names(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc;
 	as_nodes* nodes = as_nodes_reserve(as.cluster);
@@ -460,7 +460,7 @@ static ERL_NIF_TERM aspike_nif_node_get(ErlNifEnv* env, int argc, const ERL_NIF_
 	    return enif_make_badarg(env);
     }
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
     ERL_NIF_TERM rc, msg;
 
     as_node* node = as_node_get_by_name(as.cluster, node_name);
@@ -487,7 +487,7 @@ static ERL_NIF_TERM aspike_nif_node_info(ErlNifEnv* env, int argc, const ERL_NIF
 	    return enif_make_badarg(env);
     }
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
     ERL_NIF_TERM rc, msg;
 
 	as_cluster* cluster = as.cluster;
@@ -527,7 +527,7 @@ static ERL_NIF_TERM aspike_nif_help(ErlNifEnv* env, int argc, const ERL_NIF_TERM
 	    return enif_make_badarg(env);
     }
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
     ERL_NIF_TERM rc, msg;
     char * info = NULL;
     as_error err;
@@ -562,7 +562,7 @@ static ERL_NIF_TERM aspike_nif_host_info(ErlNifEnv* env, int argc, const ERL_NIF
 	    return enif_make_badarg(env);
     }
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
     ERL_NIF_TERM rc, msg;
     as_error err;
     as_address_iterator iter;
@@ -610,7 +610,7 @@ static ERL_NIF_TERM aspike_nif_host_info(ErlNifEnv* env, int argc, const ERL_NIF
 }
 
 static ERL_NIF_TERM aspike_nif_get_connections_stats(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
-    
+
     if (!statistics_enabled_flag) {
         ERL_NIF_TERM global_stats = enif_make_tuple6(env,
             enif_make_uint(env, 0),

--- a/c_src/nif/aspike_nif.h
+++ b/c_src/nif/aspike_nif.h
@@ -13,21 +13,20 @@ struct NodeConnectionStats {
     atomic<uint32_t> async_peak;
     atomic<int64_t> async_peak_ttl;
 
-    NodeConnectionStats() :
-        async_current(0), async_peak(0), async_peak_ttl(0) {}
+    NodeConnectionStats() : async_current(0), async_peak(0), async_peak_ttl(0) {}
 };
 
 enum aspike_status {
     ASPIKE_NIF_OK = 0,
-	ASPIKE_NIF_MEMORY_ALLOC_ERR = 1,
+    ASPIKE_NIF_MEMORY_ALLOC_ERR = 1,
     ASPIKE_NIF_NO_CALLER_ID = 2,
     ASPIKE_NIF_NOT_CONNECTED = 3
 };
 
 #define MAX_HOST_SIZE 1024
 #define MAX_KEY_STR_SIZE 1024
-#define MAX_NAMESPACE_SIZE 32	// based on current server limit
-#define MAX_SET_SIZE 64			// based on current server limit
+#define MAX_NAMESPACE_SIZE 32   // based on current server limit
+#define MAX_SET_SIZE 64         // based on current server limit
 #define AS_BIN_NAME_MAX_SIZE 16
 #define MAX_BINS_NUMBER 1024
 
@@ -53,18 +52,14 @@ extern shared_ptr<NodeConnectionStats> get_or_create_node_stats (const string& n
 
 extern aerospike* get_aerospike ();
 extern bool statistics_enabled ();
-extern bool check_connected (ErlNifEnv* env, ERL_NIF_TERM* err);
+extern bool is_connected (ErlNifEnv* env, ERL_NIF_TERM* err);
 
-#define RETURN_ERROR_WITH_MSG_IF(t_var, p_rec, err_code, err_msg) \
-    if(t_var) { \
-        rc = atom_error; \
-        code = enif_make_int(env, int(err_code)); \
-        msg = enif_make_string(env, err_msg, ERL_NIF_UTF8); \
-        if(p_rec) { \
-            as_record_destroy(p_rec); \
-        } \
-        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, enif_make_int(env, ASPIKE_NIF_OK), code, msg); \
-        return enif_make_tuple2(env, rc, error_tuple); \
-    }
+inline ERL_NIF_TERM make_nif_error(ErlNifEnv* env, int err_code, const char* err_msg) {
+    ERL_NIF_TERM nif_code = enif_make_int(env, ASPIKE_NIF_OK);
+    ERL_NIF_TERM aspike_code = enif_make_int(env, err_code);
+    ERL_NIF_TERM msg = enif_make_string(env, err_msg, ERL_NIF_UTF8);
+    ERL_NIF_TERM error_tuple = enif_make_tuple3(env, nif_code, aspike_code, msg);
+    return enif_make_tuple2(env, atom_error, error_tuple);
+}
 
 #endif // ASPIKE_NIF_H

--- a/c_src/nif/aspike_nif.h
+++ b/c_src/nif/aspike_nif.h
@@ -20,7 +20,8 @@ struct NodeConnectionStats {
 enum aspike_status {
     ASPIKE_NIF_OK = 0,
 	ASPIKE_NIF_MEMORY_ALLOC_ERR = 1,
-    ASPIKE_NIF_NO_CALLER_ID = 2
+    ASPIKE_NIF_NO_CALLER_ID = 2,
+    ASPIKE_NIF_NOT_CONNECTED = 3
 };
 
 #define MAX_HOST_SIZE 1024
@@ -37,7 +38,6 @@ extern ERL_NIF_TERM atom_done;
 extern ERL_NIF_TERM atom_true;
 extern ERL_NIF_TERM atom_false;
 extern ERL_NIF_TERM atom_connected;
-extern ERL_NIF_TERM atom_not_connected;
 extern ERL_NIF_TERM atom_in_progress;
 extern ERL_NIF_TERM atom_undefined;
 
@@ -60,10 +60,11 @@ extern bool check_connected (ErlNifEnv* env, ERL_NIF_TERM* err);
         rc = atom_error; \
         code = enif_make_int(env, int(err_code)); \
         msg = enif_make_string(env, err_msg, ERL_NIF_UTF8); \
-        if(!p_rec) { \
+        if(p_rec) { \
             as_record_destroy(p_rec); \
         } \
-        return enif_make_tuple3(env, rc, code, msg); \
+        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, enif_make_int(env, ASPIKE_NIF_OK), code, msg); \
+        return enif_make_tuple2(env, rc, error_tuple); \
     }
 
 #endif // ASPIKE_NIF_H

--- a/c_src/nif/async_methods.cpp
+++ b/c_src/nif/async_methods.cpp
@@ -179,7 +179,7 @@ ERL_NIF_TERM aspike_nif_cdt_put_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     long ttl;
     if (!enif_get_long(env, argv[5], &ttl)) {
@@ -260,7 +260,7 @@ ERL_NIF_TERM aspike_nif_cdt_put_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
         // {<<"fcap_map">>, [<<"map_1_name">>, <<"map_1_value">>, 123, <<"map_2_name">>, <<"map_2_value">>, 456]}
         // will form a next map:
         // KEY_ORDERED_MAP('{"map_1_name":{"ttl":123, "value":"map_1_value", "wt":1766794574}, "map_2_name":{"ttl":456, "value":"map_2_value", "wt":1766794574}}')
-        // which will be stored under a bin name "fcap_map". 
+        // which will be stored under a bin name "fcap_map".
 
         ERL_NIF_TERM bins_head, bins_tail;
         enif_get_list_cell(env, bins, &bins_head, &bins_tail);
@@ -340,7 +340,7 @@ ERL_NIF_TERM aspike_nif_cdt_put_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
                     // erl_value_data points to something like <<"map_1_value">>.
                     // Create aerospike string (a second level key name) which will be freed by context on its removal.
                     as_string* key_name = as_string_new_strdup("value");
-                    
+
                     // Use the data from erlang term (the data of which wil be available during this function lifespan).
                     // The 'false' flag means no memory free for that data.
                     as_bytes* value_data = as_bytes_new_wrap(erl_value_data.data, erl_value_data.size, false);
@@ -458,7 +458,7 @@ ERL_NIF_TERM aspike_nif_cdt_get_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
     if (!enif_inspect_binary(env, argv[3], &erl_record_name)) {
         return enif_make_badarg(env);
     }
-    
+
     string set_name((const char*)erl_set_name.data, erl_set_name.size);
     string name_space((const char*)erl_namespace.data, erl_namespace.size);
     string record_name((const char*)erl_record_name.data, erl_record_name.size);
@@ -483,7 +483,7 @@ ERL_NIF_TERM aspike_nif_cdt_get_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
     policy.base.total_timeout = total_timeout;
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     as_key record_key;
     as_key_init_str(&record_key, name_space.c_str(), set_name.c_str(), record_name.c_str());
@@ -576,7 +576,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_async(ErlNifEnv* env, int argc, const
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     string name_space((const char*)erl_ns.data, erl_ns.size);
     string set_name((const char*)erl_set_name.data, erl_set_name.size);
@@ -751,7 +751,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_batch_async(ErlNifEnv* env, int argc,
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     string name_space((const char*)erl_ns.data, erl_ns.size);
     string set_name((const char*)erl_set_name.data, erl_set_name.size);
@@ -945,7 +945,7 @@ ERL_NIF_TERM aspike_nif_segment_tag_get_async(ErlNifEnv* env, int argc, const ER
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     string name_space((const char*)erl_ns.data, erl_ns.size);
     string set_name((const char*)erl_set_name.data, erl_set_name.size);

--- a/c_src/nif/async_methods.cpp
+++ b/c_src/nif/async_methods.cpp
@@ -179,7 +179,7 @@ ERL_NIF_TERM aspike_nif_cdt_put_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     long ttl;
     if (!enif_get_long(env, argv[5], &ttl)) {
@@ -483,7 +483,7 @@ ERL_NIF_TERM aspike_nif_cdt_get_async(ErlNifEnv* env, int argc, const ERL_NIF_TE
     policy.base.total_timeout = total_timeout;
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     as_key record_key;
     as_key_init_str(&record_key, name_space.c_str(), set_name.c_str(), record_name.c_str());
@@ -576,7 +576,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_async(ErlNifEnv* env, int argc, const
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     string name_space((const char*)erl_ns.data, erl_ns.size);
     string set_name((const char*)erl_set_name.data, erl_set_name.size);
@@ -751,7 +751,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_batch_async(ErlNifEnv* env, int argc,
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     string name_space((const char*)erl_ns.data, erl_ns.size);
     string set_name((const char*)erl_set_name.data, erl_set_name.size);
@@ -945,7 +945,7 @@ ERL_NIF_TERM aspike_nif_segment_tag_get_async(ErlNifEnv* env, int argc, const ER
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     string name_space((const char*)erl_ns.data, erl_ns.size);
     string set_name((const char*)erl_set_name.data, erl_set_name.size);

--- a/c_src/nif/sync_methods.cpp
+++ b/c_src/nif/sync_methods.cpp
@@ -120,7 +120,7 @@ ERL_NIF_TERM aspike_nif_cdt_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     as_error err;
     as_key key;
@@ -233,24 +233,21 @@ ERL_NIF_TERM aspike_nif_cdt_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
 
     SyncOperationCounter conn_counter;
 
-    if (aerospike_key_operate(as, &err, &p, &key, &ops, NULL) != AEROSPIKE_OK) {
-        as_operations_destroy(&ops);
-        as_key_destroy(&key);
-        for (as_cdt_ctx* pctx : ctx_vec) {
-            as_cdt_ctx_destroy(pctx);
-        }
+    auto op_rc = aerospike_key_operate(as, &err, &p, &key, &ops, NULL);
+
+    as_operations_destroy(&ops);
+    as_key_destroy(&key);
+    // destroy all contexts
+    for (as_cdt_ctx* pctx : ctx_vec) {
+        as_cdt_ctx_destroy(pctx);
+    }
+
+    if (op_rc != AEROSPIKE_OK) {
         auto nifErrorCode = enif_make_int(env, ASPIKE_NIF_OK);
         auto aspikeErrorCode = enif_make_int(env, err.code);
         msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
         ERL_NIF_TERM error_tuple = enif_make_tuple3(env, nifErrorCode, aspikeErrorCode, msg);
         return enif_make_tuple2(env, atom_error, error_tuple);
-    }
-    as_operations_destroy(&ops);
-    as_key_destroy(&key);
-
-    // destroy all contexts
-    for (as_cdt_ctx* pctx : ctx_vec) {
-        as_cdt_ctx_destroy(pctx);
     }
 
     msg = enif_make_string(env, "put", ERL_NIF_UTF8);
@@ -294,7 +291,7 @@ ERL_NIF_TERM aspike_nif_cdt_get_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     enif_get_long(env, policy[3], &total_timeout);
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     as_error err;
@@ -372,12 +369,11 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_sync(ErlNifEnv* env, int argc, const 
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     as_arraylist remove_list;
     as_arraylist_init(&remove_list, length, length);
 
-    ERL_NIF_TERM rc, msg;
     as_error err;
     as_key key;
 
@@ -414,14 +410,10 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_sync(ErlNifEnv* env, int argc, const 
 
     if (aerospike_key_operate(as, &err, NULL, &key, &ops, NULL) != AEROSPIKE_OK) {
         as_operations_destroy(&ops);
-        auto nifErrorCode = enif_make_int(env, ASPIKE_NIF_OK);
-        auto aspikeErrorCode = enif_make_int(env, err.code);
-        msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
-        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, nifErrorCode, aspikeErrorCode, msg);
-        return enif_make_tuple2(env, atom_error, error_tuple);
+        return make_nif_error(env, int(err.code), err.message);
     }
     as_operations_destroy(&ops);
-    msg = enif_make_string(env, "keys_deleted", ERL_NIF_UTF8);
+    ERL_NIF_TERM msg = enif_make_string(env, "keys_deleted", ERL_NIF_UTF8);
     return enif_make_tuple2(env, atom_ok, msg);
 }
 
@@ -453,7 +445,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_batch_sync(ErlNifEnv* env, int argc, 
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     vector<string> bin_str_list(length);
@@ -576,9 +568,9 @@ ERL_NIF_TERM aspike_nif_segment_tag_get_sync(ErlNifEnv* env, int argc, const ERL
     aspk_columns.assign((const char*)bin_columns.data, bin_columns.size);
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
-    ERL_NIF_TERM rc, code, msg;
+    ERL_NIF_TERM rc;
     as_error err;
     as_key key;
     as_record* p_rec = NULL;
@@ -589,31 +581,26 @@ ERL_NIF_TERM aspike_nif_segment_tag_get_sync(ErlNifEnv* env, int argc, const ERL
 
     as_key_init_str(&key, name_space.c_str(), aspk_set.c_str(), aspk_key.c_str());
 
-    RETURN_ERROR_WITH_MSG_IF(
-        (aerospike_key_select(as, &err, NULL, &key, bins, &p_rec) != AEROSPIKE_OK),
-        p_rec,
-        int(err.code),
-        err.message)
+    if (aerospike_key_select(as, &err, NULL, &key, bins, &p_rec) != AEROSPIKE_OK) {
+        if (p_rec) as_record_destroy(p_rec);
+        return make_nif_error(env, int(err.code), err.message);
+    }
 
-    RETURN_ERROR_WITH_MSG_IF(
-        (p_rec == NULL),
-        p_rec,
-        int(AEROSPIKE_ERR),
-        "NULL p_rec")
+    if (p_rec == NULL) {
+        return make_nif_error(env, int(AEROSPIKE_ERR), "NULL p_rec");
+    }
 
     as_bin_value* val = as_record_get(p_rec, bins[0]);
 
-    RETURN_ERROR_WITH_MSG_IF(
-        (val == NULL),
-        p_rec,
-        int(AEROSPIKE_ERR),
-        "NULL val - internal error")
+    if (val == NULL) {
+        as_record_destroy(p_rec);
+        return make_nif_error(env, int(AEROSPIKE_ERR), "NULL val - internal error");
+    }
 
-    RETURN_ERROR_WITH_MSG_IF(
-        (as_val_type(val) != AS_STRING && as_val_type(val) != AS_MAP),
-        p_rec,
-        int(AEROSPIKE_ERR),
-        "Non-string or non-map bin - internal error")
+    if (as_val_type(val) != AS_STRING && as_val_type(val) != AS_MAP) {
+        as_record_destroy(p_rec);
+        return make_nif_error(env, int(AEROSPIKE_ERR), "Non-string or non-map bin - internal error");
+    }
 
     ERL_NIF_TERM res;
 
@@ -677,9 +664,9 @@ ERL_NIF_TERM aspike_nif_key_select_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     if (!enif_is_list(env, list) || !enif_get_list_length(env, list, &length)) {
         return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 
@@ -749,7 +736,7 @@ ERL_NIF_TERM aspike_nif_binary_get_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     aspk_key.assign((const char*)bin_key.data, bin_key.size);
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     as_error err;
@@ -796,9 +783,9 @@ ERL_NIF_TERM aspike_nif_key_get_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     if (!enif_get_string(env, argv[2], key_str, MAX_KEY_STR_SIZE, ERL_NIF_UTF8)) {
         return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     as_error err;
@@ -846,14 +833,14 @@ ERL_NIF_TERM aspike_nif_key_exists_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     if (!enif_get_string(env, argv[2], key_str, MAX_KEY_STR_SIZE, ERL_NIF_UTF8)) {
 	    return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM msg;
     as_error err;
     as_key key;
-    as_record* p_rec = NULL;    
+    as_record* p_rec = NULL;
 
 	as_key_init_str(&key, name_space, set, key_str);
     int as_rc = aerospike_key_exists(as, &err, NULL, &key, &p_rec);
@@ -890,9 +877,9 @@ ERL_NIF_TERM aspike_nif_key_inc_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     if (!enif_is_list(env, list) || !enif_get_list_length(env, list, &length)) {
 	    return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     if (length == 0) {
@@ -904,7 +891,7 @@ ERL_NIF_TERM aspike_nif_key_inc_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
 	as_error err;
     as_key key;
 	as_key_init_str(&key, name_space, set, key_str);
-	
+
     as_operations ops;
 	as_operations_inita(&ops, length);
 
@@ -960,14 +947,14 @@ ERL_NIF_TERM aspike_nif_key_generation_sync(ErlNifEnv* env, int argc, const ERL_
     if (!enif_get_string(env, argv[2], key_str, MAX_KEY_STR_SIZE, ERL_NIF_UTF8)) {
 	    return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 	as_error err;
     as_key key;
-    as_record* p_rec = NULL;    
+    as_record* p_rec = NULL;
 
 	as_key_init_str(&key, name_space, set, key_str);
 
@@ -1015,10 +1002,10 @@ ERL_NIF_TERM aspike_nif_key_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     if (!enif_is_list(env, list) || !enif_get_list_length(env, list, &length)) {
 	    return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
-    
+    if (!is_connected(env, &return_data)) return return_data;
+
     // enif_get_list_length(env, *val, &len);
     ERL_NIF_TERM rc, msg;
     if (length == 0) {
@@ -1034,7 +1021,7 @@ ERL_NIF_TERM aspike_nif_key_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
 	as_key_init_str(&key, name_space, set, key_str);
 	as_record_inita(&rec, length);
 
-    
+
     for (uint i = 0; i < length; i++) {
         ERL_NIF_TERM head;
         ERL_NIF_TERM tail;
@@ -1111,7 +1098,7 @@ ERL_NIF_TERM aspike_nif_binary_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
 	as_error err;
     as_key key;
@@ -1121,8 +1108,8 @@ ERL_NIF_TERM aspike_nif_binary_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_
 	as_record_inita(&rec, length);
     rec.ttl = ttl;
     long ret_val = 0;
-   
-    vector<as_bytes*> bin_vec; 
+
+    vector<as_bytes*> bin_vec;
     for (uint i = 0; i < length; i++) {
         ERL_NIF_TERM head;
         ERL_NIF_TERM tail;
@@ -1197,7 +1184,7 @@ ERL_NIF_TERM aspike_nif_binary_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     if (!ret_val) {
 	    // destroy heap record
     }
-	
+
     if (aerospike_key_put(as, &err, NULL, &key, &rec)  != AEROSPIKE_OK) {
         rc = atom_error;
         msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
@@ -1253,7 +1240,7 @@ ERL_NIF_TERM aspike_nif_binary_remove_sync(ErlNifEnv* env, int argc, const ERL_N
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
 	as_error err;
     as_key key;
@@ -1263,7 +1250,7 @@ ERL_NIF_TERM aspike_nif_binary_remove_sync(ErlNifEnv* env, int argc, const ERL_N
 	as_record_inita(&rec, length);
     rec.ttl = ttl;
     long ret_val = 0;
-   
+
     for (uint i = 0; i < length; i++) {
         ERL_NIF_TERM head;
         ERL_NIF_TERM tail;
@@ -1286,7 +1273,7 @@ ERL_NIF_TERM aspike_nif_binary_remove_sync(ErlNifEnv* env, int argc, const ERL_N
     if(!ret_val){
 	// destroy heap record
     }
-	
+
     if (aerospike_key_put(as, &err, NULL, &key, &rec)  != AEROSPIKE_OK) {
         rc = atom_error;
         msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
@@ -1307,7 +1294,7 @@ ERL_NIF_TERM aspike_nif_cdt_expire_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     long ttl;
 
     return enif_make_tuple2(env, atom_error, enif_make_string(env, "method not completed", ERL_NIF_UTF8));
-    
+
     if (!enif_inspect_binary(env, argv[0], &bin_ns)) {
 	    return enif_make_badarg(env);
     }
@@ -1322,20 +1309,20 @@ ERL_NIF_TERM aspike_nif_cdt_expire_sync(ErlNifEnv* env, int argc, const ERL_NIF_
 	    return enif_make_badarg(env);
     }
     aspk_key.assign((const char*) bin_key.data, bin_key.size);
-    
+
     if (!enif_get_long(env, argv[3], &ttl)) {
         return enif_make_badarg(env);
     }
 
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 	as_error err;
     as_key key;
 
 	as_key_init_str(&key, name_space.c_str(), aspk_set.c_str(), aspk_key.c_str());
-    
+
     as_cdt_ctx ctx;
     as_cdt_ctx_inita(&ctx, 1);
     as_operations ops;
@@ -1408,9 +1395,9 @@ ERL_NIF_TERM aspike_nif_key_remove_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     if (!enif_get_string(env, argv[2], key_str, MAX_KEY_STR_SIZE, ERL_NIF_UTF8)) {
 	    return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 	as_error err;
@@ -1458,9 +1445,9 @@ ERL_NIF_TERM aspike_nif_a_key_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_T
     if (!enif_get_long(env, argv[5], &n)) {
 	    return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
+    if (!is_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 	as_error err;
@@ -1473,7 +1460,7 @@ ERL_NIF_TERM aspike_nif_a_key_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_T
 
     struct timespec thread_start, thread_done;
     struct timespec real_start, real_done;
-    
+
     clock_gettime(CLOCK_THREAD_CPUTIME_ID, &thread_start);
     clock_gettime(CLOCK_REALTIME, &real_start);
 
@@ -1533,10 +1520,10 @@ ERL_NIF_TERM aspike_nif_map_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     if (!enif_get_map_size(env, erl_map, &map_size)) {
         return enif_make_badarg(env);
     }
-    
+
     ERL_NIF_TERM return_data;
-    if (!check_connected(env, &return_data)) return return_data;
-    
+    if (!is_connected(env, &return_data)) return return_data;
+
     string name_space = string((const char*)erl_namespace.data, erl_namespace.size);
     string set_name = string((const char*)erl_set_name.data, erl_set_name.size);
     string record_name((const char*)erl_record_name.data, erl_record_name.size);

--- a/c_src/nif/sync_methods.cpp
+++ b/c_src/nif/sync_methods.cpp
@@ -120,7 +120,7 @@ ERL_NIF_TERM aspike_nif_cdt_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     as_error err;
     as_key key;
@@ -234,11 +234,16 @@ ERL_NIF_TERM aspike_nif_cdt_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     SyncOperationCounter conn_counter;
 
     if (aerospike_key_operate(as, &err, &p, &key, &ops, NULL) != AEROSPIKE_OK) {
-        rc = atom_error;
+        as_operations_destroy(&ops);
+        as_key_destroy(&key);
+        for (as_cdt_ctx* pctx : ctx_vec) {
+            as_cdt_ctx_destroy(pctx);
+        }
+        auto nifErrorCode = enif_make_int(env, ASPIKE_NIF_OK);
+        auto aspikeErrorCode = enif_make_int(env, err.code);
         msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
-    } else {
-        rc = atom_ok;
-        msg = enif_make_string(env, "put", ERL_NIF_UTF8);
+        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, nifErrorCode, aspikeErrorCode, msg);
+        return enif_make_tuple2(env, atom_error, error_tuple);
     }
     as_operations_destroy(&ops);
     as_key_destroy(&key);
@@ -248,7 +253,8 @@ ERL_NIF_TERM aspike_nif_cdt_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
         as_cdt_ctx_destroy(pctx);
     }
 
-    return enif_make_tuple2(env, rc, msg);
+    msg = enif_make_string(env, "put", ERL_NIF_UTF8);
+    return enif_make_tuple2(env, atom_ok, msg);
 }
 
 ERL_NIF_TERM aspike_nif_cdt_get_sync(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
@@ -288,7 +294,7 @@ ERL_NIF_TERM aspike_nif_cdt_get_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     enif_get_long(env, policy[3], &total_timeout);
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     as_error err;
@@ -309,17 +315,20 @@ ERL_NIF_TERM aspike_nif_cdt_get_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
         if (p_rec != NULL) {
             as_record_destroy(p_rec);
         }
-        rc = atom_error;
         as_key_destroy(&key);
+        auto nifErrorCode = enif_make_int(env, ASPIKE_NIF_OK);
+        auto aspikeErrorCode = enif_make_int(env, err.code);
         msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
-        return enif_make_tuple2(env, rc, msg);
+        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, nifErrorCode, aspikeErrorCode, msg);
+        return enif_make_tuple2(env, atom_error, error_tuple);
     }
 
     as_key_destroy(&key);
     if (p_rec == NULL) {
         rc = atom_error;
         msg = enif_make_string(env, "NULL p_rec - internal error", ERL_NIF_UTF8);
-        return enif_make_tuple2(env, rc, msg);
+        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, enif_make_int(env, ASPIKE_NIF_OK), enif_make_int(env, AEROSPIKE_ERR), msg);
+        return enif_make_tuple2(env, rc, error_tuple);
     }
 
     msg = aspike_dump_cdt_records(env, p_rec);
@@ -363,7 +372,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_sync(ErlNifEnv* env, int argc, const 
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     as_arraylist remove_list;
     as_arraylist_init(&remove_list, length, length);
@@ -404,15 +413,16 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_sync(ErlNifEnv* env, int argc, const 
     SyncOperationCounter conn_counter;
 
     if (aerospike_key_operate(as, &err, NULL, &key, &ops, NULL) != AEROSPIKE_OK) {
-        rc = atom_error;
+        as_operations_destroy(&ops);
+        auto nifErrorCode = enif_make_int(env, ASPIKE_NIF_OK);
+        auto aspikeErrorCode = enif_make_int(env, err.code);
         msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
-    } else {
-        rc = atom_ok;
-        msg = enif_make_string(env, "keys_deleted", ERL_NIF_UTF8);
+        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, nifErrorCode, aspikeErrorCode, msg);
+        return enif_make_tuple2(env, atom_error, error_tuple);
     }
     as_operations_destroy(&ops);
-
-    return enif_make_tuple2(env, rc, msg);
+    msg = enif_make_string(env, "keys_deleted", ERL_NIF_UTF8);
+    return enif_make_tuple2(env, atom_ok, msg);
 }
 
 ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_batch_sync(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]) {
@@ -443,7 +453,7 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_batch_sync(ErlNifEnv* env, int argc, 
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     vector<string> bin_str_list(length);
@@ -528,9 +538,11 @@ ERL_NIF_TERM aspike_nif_cdt_delete_by_keys_batch_sync(ErlNifEnv* env, int argc, 
 
     as_batch_records_destroy(&recs);
     if (status != AEROSPIKE_OK) {
-        rc = atom_error;
+        auto nifErrorCode = enif_make_int(env, ASPIKE_NIF_OK);
+        auto aspikeErrorCode = enif_make_int(env, err.code);
         msg = enif_make_string(env, err.message, ERL_NIF_UTF8);
-        return enif_make_tuple2(env, rc, msg);
+        ERL_NIF_TERM error_tuple = enif_make_tuple3(env, nifErrorCode, aspikeErrorCode, msg);
+        return enif_make_tuple2(env, atom_error, error_tuple);
     } else {
         rc = atom_ok;
         return enif_make_tuple2(env, rc, opsl);
@@ -564,7 +576,7 @@ ERL_NIF_TERM aspike_nif_segment_tag_get_sync(ErlNifEnv* env, int argc, const ERL
     aspk_columns.assign((const char*)bin_columns.data, bin_columns.size);
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, code, msg;
     as_error err;
@@ -667,7 +679,7 @@ ERL_NIF_TERM aspike_nif_key_select_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 
@@ -737,7 +749,7 @@ ERL_NIF_TERM aspike_nif_binary_get_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     aspk_key.assign((const char*)bin_key.data, bin_key.size);
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     as_error err;
@@ -786,7 +798,7 @@ ERL_NIF_TERM aspike_nif_key_get_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     as_error err;
@@ -836,7 +848,7 @@ ERL_NIF_TERM aspike_nif_key_exists_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM msg;
     as_error err;
@@ -880,7 +892,7 @@ ERL_NIF_TERM aspike_nif_key_inc_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
     if (length == 0) {
@@ -950,7 +962,7 @@ ERL_NIF_TERM aspike_nif_key_generation_sync(ErlNifEnv* env, int argc, const ERL_
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 	as_error err;
@@ -1005,7 +1017,7 @@ ERL_NIF_TERM aspike_nif_key_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
     
     // enif_get_list_length(env, *val, &len);
     ERL_NIF_TERM rc, msg;
@@ -1099,7 +1111,7 @@ ERL_NIF_TERM aspike_nif_binary_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
 	as_error err;
     as_key key;
@@ -1241,7 +1253,7 @@ ERL_NIF_TERM aspike_nif_binary_remove_sync(ErlNifEnv* env, int argc, const ERL_N
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
 	as_error err;
     as_key key;
@@ -1316,7 +1328,7 @@ ERL_NIF_TERM aspike_nif_cdt_expire_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     }
 
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 	as_error err;
@@ -1398,7 +1410,7 @@ ERL_NIF_TERM aspike_nif_key_remove_sync(ErlNifEnv* env, int argc, const ERL_NIF_
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 	as_error err;
@@ -1448,7 +1460,7 @@ ERL_NIF_TERM aspike_nif_a_key_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_T
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
 
     ERL_NIF_TERM rc, msg;
 	as_error err;
@@ -1523,7 +1535,7 @@ ERL_NIF_TERM aspike_nif_map_put_sync(ErlNifEnv* env, int argc, const ERL_NIF_TER
     }
     
     ERL_NIF_TERM return_data;
-    if (check_connected(env, &return_data)) return return_data;
+    if (!check_connected(env, &return_data)) return return_data;
     
     string name_space = string((const char*)erl_namespace.data, erl_namespace.size);
     string set_name = string((const char*)erl_set_name.data, erl_set_name.size);

--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,12 @@
 
 {src_dirs, ["src"]}.
 
+{eunit_opts, [verbose]}.
+{eunit_tests, [
+    {module, aspike_nif_not_connected_test},
+    {module, aspike_nif_eunit_test}
+]}.
+
 {deps, [
     {pooler, "1.6.0"}
 ]}.

--- a/src/aspike_nif.erl
+++ b/src/aspike_nif.erl
@@ -6,6 +6,7 @@
 -include_lib("kernel/include/logger.hrl").
 
 -export([
+    init_client/0,
     host_add/0,
     host_add/1,
     host_add/2,
@@ -75,6 +76,7 @@
 ]).
 
 -nifs([
+    init_client/0,
     nif_host_add/2,
     host_clear/0,
     nif_host_list/0,
@@ -137,6 +139,10 @@ init() ->
 
 not_loaded(Line) ->
     erlang:nif_error({not_loaded, [{module, ?MODULE}, {line, Line}]}).
+
+-spec init_client() -> {ok, string()}.
+init_client() ->
+    not_loaded(?LINE).
 
 -spec host_add() -> {ok, string()} | {error, string()}.
 host_add() ->

--- a/src/aspike_nif.erl
+++ b/src/aspike_nif.erl
@@ -18,6 +18,7 @@
     enable_statistic_collection/1,
     connect/0,
     connect/2,
+    disconnect/0,
     is_connected/0,
     get_connections_stats/0,
     key_exists/0,
@@ -81,6 +82,7 @@
     set_event_loops_amount/1,
     enable_statistic_collection/1,
     connect/2,
+    disconnect/0,
     is_connected/0,
     get_connections_stats/0,
     key_exists/3,
@@ -199,6 +201,10 @@ connect() ->
 % @doc Create connection using User and PWd credential
 -spec connect(string(), string()) -> {ok, connected} | {error, string()}.
 connect(_, _) ->
+    not_loaded(?LINE).
+
+-spec disconnect() -> {ok, string()} | {error, string()}.
+disconnect() ->
     not_loaded(?LINE).
 
 -spec is_connected() -> false | true.

--- a/src/aspike_nif.erl
+++ b/src/aspike_nif.erl
@@ -265,9 +265,9 @@ binary_put(_Namespace, _Set, _Key, _BinList, _TTL) ->
     not_loaded(?LINE).
 
 -spec cdt_put_sync(binary(), binary(), binary(),
-        [{binary(), binary()|integer()|[integer()]}], integer(), 
+        [{binary(), binary()|integer()|[integer()]}], integer(),
         {integer(), integer(), integer(), integer()}) ->
-            {ok, string()} | {error, string()}.
+            {ok, string()} | {error, {integer(), integer(), string()}}.
 cdt_put_sync(_Namespace, _Set, _RecordKeyName, _BinList, _TTL, _Policy) ->
     not_loaded(?LINE).
 
@@ -278,7 +278,7 @@ cdt_put_sync(_Namespace, _Set, _RecordKeyName, _BinList, _TTL, _Policy) ->
 cdt_put_async(_Ref, _Namespace, _Set, _RecordKeyName, _BinList, _TTL, _Policy) ->
     not_loaded(?LINE).
 
--spec cdt_get_sync(binary(), binary(), binary(), {integer(), integer(), integer(), integer()}) -> {ok, [{binary(), term()}]} | {error, string()}.
+-spec cdt_get_sync(binary(), binary(), binary(), {integer(), integer(), integer(), integer()}) -> {ok, [{binary(), term()}]} | {error, {integer(), integer(), string()}}.
 cdt_get_sync(_Namespace, _Set, _RecordKeyName, _Policy) ->
     not_loaded(?LINE).
 
@@ -340,11 +340,11 @@ binary_get(Namespace, Set, Key) when is_binary(Namespace), is_binary(Set), is_bi
 map_put(_Namespace, _Set, _RecordKey, _BinName, _TTL, _Map) ->
     not_loaded(?LINE).
 
--spec segment_tag_get_sync(binary(), binary(), binary(), binary()) -> {ok, binary() | map()} | {error, string()} | {error, integer(), string()}.
+-spec segment_tag_get_sync(binary(), binary(), binary(), binary()) -> {ok, binary() | map()} | {error, {integer(), integer(), string()}}.
 segment_tag_get_sync(Namespace, Set, Key, BinName) when is_binary(Namespace), is_binary(Set), is_binary(Key), is_binary(BinName) ->
     not_loaded(?LINE).
 
--spec segment_tag_get_async(reference(), binary(), binary(), binary(), binary()) -> {ok, binary() | map()} | {error, string()} | {error, integer(), string()}.
+-spec segment_tag_get_async(reference(), binary(), binary(), binary(), binary()) -> {ok, binary() | map()} | {error, {integer(), integer(), string()}}.
 segment_tag_get_async(_Ref, _Namespace, _Set, _Key, _BinName) ->
     not_loaded(?LINE).
 
@@ -352,7 +352,7 @@ segment_tag_get_async(_Ref, _Namespace, _Set, _Key, _BinName) ->
 cdt_expire(Namespace, Set, Key, TTL) when is_binary(Namespace), is_binary(Set), is_binary(Key), is_integer(TTL) ->
     not_loaded(?LINE).
 
--spec cdt_delete_by_keys_sync(binary(), binary(), binary(), binary(), [binary()]) -> {ok, string()} | {error, string()}.
+-spec cdt_delete_by_keys_sync(binary(), binary(), binary(), binary(), [binary()]) -> {ok, string()} | {error, {integer(), integer(), string()}}.
 cdt_delete_by_keys_sync(Namespace, Set, RecordKeyName, BinName, SubkeysList) when is_binary(Namespace), is_binary(Set), is_binary(RecordKeyName), is_binary(BinName), is_list(SubkeysList) ->
     not_loaded(?LINE).
 
@@ -360,7 +360,7 @@ cdt_delete_by_keys_sync(Namespace, Set, RecordKeyName, BinName, SubkeysList) whe
 cdt_delete_by_keys_async(_Ref, _Namespace, _Set, _RecordKeyName, _BinName, _SubkeysList) ->
     not_loaded(?LINE).
 
--spec cdt_delete_by_keys_batch_sync(binary(), binary(), binary(), [{binary(), [binary()]}]) -> {ok, [integer()]} | {error, string()}.
+-spec cdt_delete_by_keys_batch_sync(binary(), binary(), binary(), [{binary(), [binary()]}]) -> {ok, [integer()]} | {error, {integer(), integer(), string()}}.
 cdt_delete_by_keys_batch_sync(Namespace, Set, BinName, KeysToRemove) when is_binary(Namespace), is_binary(Set), is_binary(BinName), is_list(KeysToRemove) ->
     not_loaded(?LINE).
 

--- a/test/aspike_nif_eunit_test.erl
+++ b/test/aspike_nif_eunit_test.erl
@@ -338,7 +338,8 @@ test_disconnect_and_reconnect() ->
     % operations should fail while disconnected
     Result = aspike_nif:cdt_get_sync(?NAMESPACE, ?SET, <<"any_key">>, {3, 250, 30000, 1000}),
     ?assertMatch({error, {_, _, "not_connected"}}, Result),
-    % reconnect — after disconnect, full re-init is needed
+    % reconnect — after disconnect, re-init the client first
+    aspike_nif:init_client(),
     aspike_nif:host_add(),
     ?assertMatch({ok, _}, aspike_nif:connect()),
     ?assert(aspike_nif:is_connected()),

--- a/test/aspike_nif_eunit_test.erl
+++ b/test/aspike_nif_eunit_test.erl
@@ -29,7 +29,8 @@ all_test_() ->
             {"get_absent_record_async", fun test_get_absent_record_async/0},
             {"multi_bin_write", fun test_multi_bin_write/0},
             {"batch_insert_large_bin", fun test_batch_insert_large_bin/0},
-            {"cdt_put_then_map_put_same_bin", fun test_cdt_put_then_map_put_same_bin/0}
+            {"cdt_put_then_map_put_same_bin", fun test_cdt_put_then_map_put_same_bin/0},
+            {"disconnect_and_reconnect", fun test_disconnect_and_reconnect/0}
         ]
     }.
 
@@ -329,6 +330,23 @@ test_cdt_put_get_mixed(WriteMode, ReadMode) ->
         ?assertEqual(Value, ActualValue),
         ?assertEqual(ExpTTL, ActualTTL)
     end, WrittenItems).
+
+test_disconnect_and_reconnect() ->
+    ?assert(aspike_nif:is_connected()),
+    ?assertMatch({ok, _}, aspike_nif:disconnect()),
+    ?assertNot(aspike_nif:is_connected()),
+    % operations should fail while disconnected
+    Result = aspike_nif:cdt_get_sync(?NAMESPACE, ?SET, <<"any_key">>, {3, 250, 30000, 1000}),
+    ?assertMatch({error, {_, _, "not_connected"}}, Result),
+    % reconnect — after disconnect, full re-init is needed
+    aspike_nif:host_add(),
+    ?assertMatch({ok, _}, aspike_nif:connect()),
+    ?assert(aspike_nif:is_connected()),
+    % verify operations work after reconnect
+    PK = <<"eunit_reconnect_test">>,
+    Bins = [{<<"data">>, [<<"k1">>, <<1, 2, 3>>, 100]}],
+    assert_put_ok(cdt_put(sync, ?NAMESPACE, ?SET, PK, Bins, 60)),
+    ?assertMatch({ok, _}, cdt_get(sync, ?NAMESPACE, ?SET, PK)).
 
 %% Helpers
 

--- a/test/aspike_nif_not_connected_test.erl
+++ b/test/aspike_nif_not_connected_test.erl
@@ -1,0 +1,87 @@
+-module(aspike_nif_not_connected_test).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(NAMESPACE, <<"test">>).
+-define(SET, <<"test_set">>).
+-define(KEY, <<"test_key">>).
+-define(POLICY, {3, 250, 30000, 1000}).
+
+all_test_() ->
+    {setup,
+        fun setup/0,
+        fun cleanup/1,
+        [
+            {"cdt_put_sync not connected", fun cdt_put_sync_not_connected/0},
+            {"cdt_get_sync not connected", fun cdt_get_sync_not_connected/0},
+            {"cdt_put_async not connected", fun cdt_put_async_not_connected/0},
+            {"cdt_get_async not connected", fun cdt_get_async_not_connected/0},
+            {"cdt_delete_by_keys_sync not connected", fun cdt_delete_by_keys_sync_not_connected/0},
+            {"cdt_delete_by_keys_async not connected", fun cdt_delete_by_keys_async_not_connected/0},
+            {"cdt_delete_by_keys_batch_sync not connected", fun cdt_delete_by_keys_batch_sync_not_connected/0},
+            {"cdt_delete_by_keys_batch_async not connected", fun cdt_delete_by_keys_batch_async_not_connected/0},
+            {"segment_tag_get_sync not connected", fun segment_tag_get_sync_not_connected/0},
+            {"segment_tag_get_async not connected", fun segment_tag_get_async_not_connected/0}
+        ]
+    }.
+
+setup() ->
+    % Calling any function ensures the module (and NIF) is loaded via on_load.
+    % We intentionally do NOT call connect() — operations should fail with not_connected.
+    aspike_nif:is_connected(),
+    ok.
+
+cleanup(_) ->
+    ok.
+
+cdt_put_sync_not_connected() ->
+    Bins = [{<<"bin">>, [<<"k">>, <<1, 2, 3>>, 100]}],
+    Result = aspike_nif:cdt_put_sync(?NAMESPACE, ?SET, ?KEY, Bins, 300, ?POLICY),
+    assert_not_connected(Result).
+
+cdt_get_sync_not_connected() ->
+    Result = aspike_nif:cdt_get_sync(?NAMESPACE, ?SET, ?KEY, ?POLICY),
+    assert_not_connected(Result).
+
+cdt_put_async_not_connected() ->
+    Ref = make_ref(),
+    Bins = [{<<"bin">>, [<<"k">>, <<1, 2, 3>>, 100]}],
+    Result = aspike_nif:cdt_put_async(Ref, ?NAMESPACE, ?SET, ?KEY, Bins, 300, ?POLICY),
+    assert_not_connected(Result).
+
+cdt_get_async_not_connected() ->
+    Ref = make_ref(),
+    Result = aspike_nif:cdt_get_async(Ref, ?NAMESPACE, ?SET, ?KEY, ?POLICY),
+    assert_not_connected(Result).
+
+cdt_delete_by_keys_sync_not_connected() ->
+    Result = aspike_nif:cdt_delete_by_keys_sync(?NAMESPACE, ?SET, ?KEY, <<"bin">>, [<<"k">>]),
+    assert_not_connected(Result).
+
+cdt_delete_by_keys_async_not_connected() ->
+    Ref = make_ref(),
+    Result = aspike_nif:cdt_delete_by_keys_async(Ref, ?NAMESPACE, ?SET, ?KEY, <<"bin">>, [<<"k">>]),
+    assert_not_connected(Result).
+
+cdt_delete_by_keys_batch_sync_not_connected() ->
+    Result = aspike_nif:cdt_delete_by_keys_batch_sync(?NAMESPACE, ?SET, <<"bin">>, [{?KEY, [<<"k">>]}]),
+    assert_not_connected(Result).
+
+cdt_delete_by_keys_batch_async_not_connected() ->
+    Ref = make_ref(),
+    Result = aspike_nif:cdt_delete_by_keys_batch_async(Ref, ?NAMESPACE, ?SET, <<"bin">>, [{?KEY, [<<"k">>]}]),
+    assert_not_connected(Result).
+
+segment_tag_get_sync_not_connected() ->
+    Result = aspike_nif:segment_tag_get_sync(?NAMESPACE, ?SET, ?KEY, <<"tag">>),
+    assert_not_connected(Result).
+
+segment_tag_get_async_not_connected() ->
+    Ref = make_ref(),
+    Result = aspike_nif:segment_tag_get_async(Ref, ?NAMESPACE, ?SET, ?KEY, <<"tag">>),
+    assert_not_connected(Result).
+
+assert_not_connected(Result) ->
+    ?assertMatch({error, {_, _, _}}, Result),
+    {error, {_NifCode, _AspikeCode, Msg}} = Result,
+    ?assertEqual("not_connected", Msg).

--- a/test/aspike_nif_not_connected_test.erl
+++ b/test/aspike_nif_not_connected_test.erl
@@ -21,14 +21,18 @@ all_test_() ->
             {"cdt_delete_by_keys_batch_sync not connected", fun cdt_delete_by_keys_batch_sync_not_connected/0},
             {"cdt_delete_by_keys_batch_async not connected", fun cdt_delete_by_keys_batch_async_not_connected/0},
             {"segment_tag_get_sync not connected", fun segment_tag_get_sync_not_connected/0},
-            {"segment_tag_get_async not connected", fun segment_tag_get_async_not_connected/0}
+            {"segment_tag_get_async not connected", fun segment_tag_get_async_not_connected/0},
+            {"disconnect when not connected", fun disconnect_when_not_connected/0}
         ]
     }.
 
 setup() ->
-    % Calling any function ensures the module (and NIF) is loaded via on_load.
-    % We intentionally do NOT call connect() — operations should fail with not_connected.
-    aspike_nif:is_connected(),
+    % Ensure we are disconnected — if another test module connected before us,
+    % disconnect so we can test the not-connected error paths.
+    case aspike_nif:is_connected() of
+        true -> aspike_nif:disconnect();
+        false -> ok
+    end,
     ok.
 
 cleanup(_) ->
@@ -80,6 +84,10 @@ segment_tag_get_async_not_connected() ->
     Ref = make_ref(),
     Result = aspike_nif:segment_tag_get_async(Ref, ?NAMESPACE, ?SET, ?KEY, <<"tag">>),
     assert_not_connected(Result).
+
+disconnect_when_not_connected() ->
+    Result = aspike_nif:disconnect(),
+    ?assertEqual({ok, "disconnected"}, Result).
 
 assert_not_connected(Result) ->
     ?assertMatch({error, {_, _, _}}, Result),


### PR DESCRIPTION
## Summary

- **Standardize error return format**: All NIF error returns now use a consistent `{error, {NifErrorCode, AerospikeErrorCode, Message}}` tuple instead of the previous mix of `{error, atom()}` and `{error, string()}` formats. This makes error handling on the Erlang side uniform and machine-parseable.
- **Add `disconnect/0` NIF**: New function to cleanly close the Aerospike connection, destroy the client, and re-initialize so that `host_add/connect` can be called again. Idempotent — returns `{ok, "disconnected"}` even if already disconnected.
- **Fix `check_connected` semantics**: Inverted the return value (`true` = connected, `false` = not connected) to match natural boolean reading. All call sites updated from `if (check_connected(...))` to `if (!check_connected(...))`.
- **Fix `as_record_destroy` guard in `CHECK_AND_RETURN_ERROR` macro**: The condition was inverted (`!p_rec` → `p_rec`), so the record is now correctly destroyed only when non-NULL.
- **Add `aspike_nif_not_connected_test` module**: Dedicated EUnit suite that verifies all operations return the proper error tuple when not connected.
- **Update `Makefile` and `rebar.config`**: Tests now run all modules (not just `aspike_nif_eunit_test`), and test beam paths point to the correct test output directory instead of the pooler dependency.

## Test plan

- [x] `aspike_nif_not_connected_test` covers all sync/async NIF operations when disconnected
- [x] `aspike_nif_eunit_test` includes a disconnect-and-reconnect round-trip test
- [x] Run full `make test` against a live Aerospike instance to validate both test modules pass
- [x] tested on live instances